### PR TITLE
Setup trunk and update rustc version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 .cargo-ok
 .DS_Store
+dist/
 {% if crate_type == "lib" %}
 Cargo.lock
 {% endif %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+wasm-bindgen = "0.2.100"
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rust WASM</title>
+  </head>
+  <body>
+    <link data-trunk rel="rust" />
+  </body>
+</html>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.76.0"
+components = ["rust-src"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn greet() -> String {
+    "Hello, World!".to_string()
 }


### PR DESCRIPTION
This commit sets up the project to use `trunk` for building the WebAssembly module. It also updates the `rust-toolchain.toml` to use a specific version of the Rust compiler.

The following changes were made:
- Installed `trunk` and `wasm-bindgen-cli`.
- Updated `rust-toolchain.toml` to use Rust `1.76.0`.
- Created an `index.html` file as the entry point for the application.
- Added `wasm-bindgen` as a dependency to `Cargo.toml`.
- Added a simple `greet` function to `src/lib.rs` to demonstrate the wasm build.
- Added `dist/` to the `.gitignore` file.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
