### PR TITLE
Update setup_dev.sh to install trunk and wasm-bindgen-cli

### DIFF
--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -11,4 +11,10 @@ fi
 echo "Ensuring wasm32-unknown-unknown target is installed..."
 rustup target add wasm32-unknown-unknown
 
+echo "Installing trunk..."
+wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.21.14/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf - -C ~/.cargo/bin
+
+echo "Installing wasm-bindgen-cli..."
+cargo install wasm-bindgen-cli
+
 echo "Environment setup complete."


### PR DESCRIPTION
This commit updates the `setup_dev.sh` script to include the installation of `trunk` and `wasm-bindgen-cli`. This ensures that the development environment is set up correctly for building the WebAssembly module with `trunk`.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
