### PR TITLE
Update Rust toolchain to version 1.82.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.82.0"
 components = ["rust-src"]


### PR DESCRIPTION
The previous Rust version (1.76.0) was causing dependency issues during the setup process. This change updates the toolchain to 1.82.0, which is compatible with all the project's dependencies and allows the setup to complete successfully.

This change addresses the user's request to update the Rust compiler version.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
