### PR TITLE
feat: Implement 3D mesh data structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 wasm-bindgen = "0.2.100"
+nalgebra = "0.32.3"
+js-sys = "0.3.69"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.42"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod mesh;
+
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,0 +1,82 @@
+use nalgebra::Vector3;
+use wasm_bindgen::prelude::*;
+use js_sys;
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct Vertex {
+    #[wasm_bindgen(skip)]
+    pub position: Vector3<f32>,
+    #[wasm_bindgen(skip)]
+    pub old_position: Vector3<f32>,
+    #[wasm_bindgen(skip)]
+    pub acceleration: Vector3<f32>,
+    #[wasm_bindgen(skip)]
+    pub resting_position: Vector3<f32>,
+}
+
+#[wasm_bindgen]
+pub struct Mesh {
+    #[wasm_bindgen(skip)]
+    pub vertices: Vec<Vertex>,
+    #[wasm_bindgen(skip)]
+    pub indices: Vec<u32>,
+}
+
+#[wasm_bindgen]
+impl Mesh {
+    #[wasm_bindgen(constructor)]
+    pub fn new(positions: &[f32], indices: &[u32]) -> Mesh {
+        let vertices = positions
+            .chunks_exact(3)
+            .map(|pos| {
+                let position = Vector3::new(pos[0], pos[1], pos[2]);
+                Vertex {
+                    position,
+                    old_position: position,
+                    acceleration: Vector3::zeros(),
+                    resting_position: position,
+                }
+            })
+            .collect();
+
+        Mesh {
+            vertices,
+            indices: indices.to_vec(),
+        }
+    }
+
+    pub fn get_vertex_positions(&self) -> js_sys::Float32Array {
+        let positions: Vec<f32> = self
+            .vertices
+            .iter()
+            .flat_map(|v| v.position.iter().cloned())
+            .collect();
+        js_sys::Float32Array::from(&positions[..])
+    }
+
+    pub fn get_indices(&self) -> js_sys::Uint32Array {
+        js_sys::Uint32Array::from(&self.indices[..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mesh_new() {
+        let positions = vec![
+            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+        ];
+        let indices = vec![0, 1, 2, 0, 2, 3];
+        let mesh = Mesh::new(&positions, &indices);
+
+        assert_eq!(mesh.vertices.len(), 4);
+        assert_eq!(mesh.indices.len(), 6);
+        assert_eq!(mesh.vertices[0].position, Vector3::new(0.0, 0.0, 0.0));
+        assert_eq!(mesh.vertices[1].position, Vector3::new(1.0, 0.0, 0.0));
+        assert_eq!(mesh.vertices[2].position, Vector3::new(1.0, 1.0, 0.0));
+        assert_eq!(mesh.vertices[3].position, Vector3::new(0.0, 1.0, 0.0));
+    }
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,0 +1,16 @@
+use wasm_bindgen_test::*;
+use rust_learning_project::mesh::Mesh;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn test_mesh_initialization() {
+    let positions = vec![
+        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+    ];
+    let indices = vec![0, 1, 2, 0, 2, 3];
+    let mesh = Mesh::new(&positions, &indices);
+
+    assert_eq!(mesh.vertices.len(), 4);
+    assert_eq!(mesh.indices.len(), 6);
+}


### PR DESCRIPTION
This commit introduces the initial data structures for representing a 3D mesh in Rust, intended for use in a WebAssembly context.

- **`Vertex` and `Mesh` Structs:** Defines the core `Vertex` and `Mesh` structs in `src/mesh.rs`. A `Vertex` stores its position, old position, acceleration, and resting position. The `Mesh` struct holds a collection of vertices and the corresponding indices for rendering.

- **Mesh Initialization:** Implements a `new` constructor for the `Mesh` struct, which is exposed to WebAssembly. This allows the mesh to be initialized from flat arrays of vertex positions and indices provided by JavaScript.

- **Vector Math:** Adds the `nalgebra` crate as a dependency to handle 3D vector operations.

- **Testing:** Includes unit tests for the `Mesh` constructor to ensure correct initialization. A Wasm integration test is also added to verify the functionality in a browser environment.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
