### PR TITLE
feat: Implement custom spring-mass physics engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,9 @@ js-sys = "0.3.69"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"
 
+[[test]]
+name = "physics"
+path = "tests/physics.rs"
+
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod mesh;
+pub mod physics;
 
 use wasm_bindgen::prelude::*;
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,0 +1,23 @@
+use nalgebra::Vector3;
+
+pub struct Spring {
+    pub vertex_a_index: usize,
+    pub vertex_b_index: usize,
+    pub rest_length: f32,
+    pub stiffness: f32,
+    pub damping: f32,
+}
+
+pub struct Physics {
+    pub time_step: f32,
+    pub gravity: Vector3<f32>,
+}
+
+impl Physics {
+    pub fn new() -> Self {
+        Self {
+            time_step: 0.01,
+            gravity: Vector3::new(0.0, -9.81, 0.0),
+        }
+    }
+}

--- a/tests/physics.rs
+++ b/tests/physics.rs
@@ -1,0 +1,95 @@
+use rust_learning_project::mesh::{Mesh, Vertex};
+use rust_learning_project::physics::Spring;
+use nalgebra::Vector3;
+
+#[test]
+fn test_spring_force() {
+    let mut mesh = Mesh::new(&[], &[]);
+    mesh.vertices = vec![
+        Vertex {
+            position: Vector3::new(0.0, 0.0, 0.0),
+            old_position: Vector3::new(0.0, 0.0, 0.0),
+            acceleration: Vector3::zeros(),
+            resting_position: Vector3::new(0.0, 0.0, 0.0),
+            mass: 1.0,
+        },
+        Vertex {
+            position: Vector3::new(2.0, 0.0, 0.0),
+            old_position: Vector3::new(2.0, 0.0, 0.0),
+            acceleration: Vector3::zeros(),
+            resting_position: Vector3::new(1.0, 0.0, 0.0),
+            mass: 1.0,
+        },
+    ];
+    mesh.springs = vec![Spring {
+        vertex_a_index: 0,
+        vertex_b_index: 1,
+        rest_length: 1.0,
+        stiffness: 100.0,
+        damping: 0.0,
+    }];
+
+    mesh.update();
+
+    // The spring is stretched by 1.0 unit, so the force should be 100.0 * 1.0 = 100.0
+    // The force is applied in the direction from vertex_b to vertex_a
+    // The acceleration is force / mass (assuming mass = 1.0)
+    assert_eq!(mesh.vertices[0].acceleration.x, 100.0);
+    assert_eq!(mesh.vertices[1].acceleration.x, -100.0);
+}
+
+#[test]
+fn test_verlet_integration() {
+    let mut mesh = Mesh::new(&[], &[]);
+    mesh.vertices = vec![Vertex {
+        position: Vector3::new(0.0, 0.0, 0.0),
+        old_position: Vector3::new(0.0, 0.0, 0.0),
+        acceleration: Vector3::new(0.0, -10.0, 0.0),
+        resting_position: Vector3::new(0.0, 0.0, 0.0),
+        mass: 1.0,
+    }];
+    mesh.physics.time_step = 0.1;
+    mesh.physics.gravity = Vector3::new(0.0, -10.0, 0.0);
+
+    mesh.update();
+
+    // After 1st step:
+    // pos = 0 + (0 - 0) + (0, -10, 0) * 0.1 * 0.1 = (0, -0.1, 0)
+    assert_eq!(mesh.vertices[0].position.y, -0.1);
+
+    mesh.update();
+
+    // After 2nd step:
+    // pos = -0.1 + (-0.1 - 0) + (0, -10, 0) * 0.1 * 0.1 = -0.1 - 0.1 - 0.1 = -0.3
+    assert_eq!(mesh.vertices[0].position.y, -0.3);
+}
+
+#[test]
+fn test_oscillation() {
+    let mut mesh = Mesh::new(
+        &[0.0, 0.0, 0.0, 1.1, 0.0, 0.0],
+        &[],
+    );
+    mesh.vertices[0].mass = 0.0; // Pin this vertex
+    mesh.springs = vec![Spring {
+        vertex_a_index: 0,
+        vertex_b_index: 1,
+        rest_length: 1.0,
+        stiffness: 100.0,
+        damping: 0.0,
+    }];
+    mesh.physics.gravity = Vector3::zeros();
+    mesh.physics.time_step = 0.01;
+
+    // Initial position of vertex 1 is 1.1, rest length is 1.0.
+    // It should move towards vertex 0.
+    mesh.update();
+    assert!(mesh.vertices[1].position.x < 1.1);
+
+    // Let it run for a while, it should oscillate around the rest length.
+    for _ in 0..100 {
+        mesh.update();
+    }
+    // After 100 steps, it should have oscillated back and be on the other side.
+    assert!(mesh.vertices[1].position.x < 1.0);
+}


### PR DESCRIPTION
This commit introduces a lightweight, custom spring-mass physics system to simulate soft-body dynamics for the 3D mesh.

Key changes:
- Created a new `physics.rs` module with `Spring` and `Physics` structs to define the physical model.
- Integrated the physics model into the `Mesh` struct in `mesh.rs`, which now includes springs, physics parameters, and an `update` method for simulation.
- Implemented Verlet integration for updating vertex positions based on spring forces (Hooke's Law and damping) and external forces.
- Added an `apply_force` method to allow for user interaction with the mesh.
- Spring constraints are automatically generated from the mesh's edges during initialization.
- Added a comprehensive suite of unit tests in `tests/physics.rs` to verify the correctness of the spring force calculations, Verlet integration, and oscillation behavior.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
