### PR TITLE
feat: initialize Three.js environment for scene setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .cargo-ok
 .DS_Store
 dist/
+node_modules/
+package-lock.json
 {% if crate_type == "lib" %}
 Cargo.lock
 {% endif %}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
     <title>Rust WASM</title>
   </head>
   <body>
+    <canvas id="webgl"></canvas>
     <link data-trunk rel="rust" />
+    <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,47 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+// Scene
+const scene = new THREE.Scene();
+
+// Camera
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.z = 5;
+
+// Renderer
+const canvas = document.querySelector('#webgl');
+const renderer = new THREE.WebGLRenderer({
+    canvas: canvas,
+    antialias: true
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+// Lights
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
+scene.add(ambientLight);
+
+const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
+directionalLight.position.set(2, 2, 5);
+scene.add(directionalLight);
+
+// Controls
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+
+// Animation loop
+const animate = () => {
+    controls.update();
+    renderer.render(scene, camera);
+    window.requestAnimationFrame(animate);
+};
+
+animate();
+
+// Handle window resize
+window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "three-js-project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "three": "^0.166.1"
+  }
+}


### PR DESCRIPTION
This pull request adds Three.js to the project to enable 3D rendering in the browser, sets up the basic scene, camera, lighting, and controls, and introduces a `package.json` for dependency management. The main HTML file is also updated to include a canvas and load the new JavaScript entry point.

**Three.js integration and 3D scene setup:**

* Added a new `main.js` that initializes a Three.js scene, camera, renderer, ambient and directional lights, and orbit controls for user interaction. The script also handles window resizing and starts an animation loop. (`main.js`)
* Updated `index.html` to include a `<canvas id="webgl"></canvas>` for rendering the 3D scene and to load the new `main.js` script as a module. (`index.html`)

**Project configuration:**

* Added a `package.json` to manage dependencies, specifying Three.js as a dependency and setting the project up as an ES module. (`package.json`)