### PR TITLE
chore: add rustfmt setup and format code

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.83.0"
-components = ["rust-src"]
+components = ["rust-src", "rustfmt"]

--- a/setup_dev.sh
+++ b/setup_dev.sh
@@ -8,6 +8,9 @@ then
     exit 1
 fi
 
+echo "Ensuring rustfmt component is installed..."
+rustup component add rustfmt
+
 echo "Ensuring wasm32-unknown-unknown target is installed..."
 rustup target add wasm32-unknown-unknown
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,8 +1,8 @@
 use crate::physics::{self, Physics, Spring};
+use js_sys;
 use nalgebra::Vector3;
 use std::collections::HashSet;
 use wasm_bindgen::prelude::*;
-use js_sys;
 
 #[wasm_bindgen]
 #[derive(Clone, Copy)]
@@ -53,7 +53,11 @@ impl Mesh {
         let mut existing_springs = HashSet::new();
 
         for triangle in indices.chunks_exact(3) {
-            let (a, b, c) = (triangle[0] as usize, triangle[1] as usize, triangle[2] as usize);
+            let (a, b, c) = (
+                triangle[0] as usize,
+                triangle[1] as usize,
+                triangle[2] as usize,
+            );
 
             let edges = [(a, b), (b, c), (c, a)];
             for (v1_idx, v2_idx) in edges.iter() {
@@ -64,7 +68,8 @@ impl Mesh {
                 };
 
                 if existing_springs.insert((v1_idx, v2_idx)) {
-                    let rest_length = (vertices[v1_idx].position - vertices[v2_idx].position).magnitude();
+                    let rest_length =
+                        (vertices[v1_idx].position - vertices[v2_idx].position).magnitude();
                     springs.push(Spring {
                         vertex_a_index: v1_idx,
                         vertex_b_index: v2_idx,
@@ -124,9 +129,7 @@ mod tests {
 
     #[test]
     fn test_mesh_new() {
-        let positions = vec![
-            0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
-        ];
+        let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
         let indices = vec![0, 1, 2, 0, 2, 3];
         let mesh = Mesh::new(&positions, &indices);
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -58,8 +58,9 @@ pub fn update(mesh: &mut Mesh, time_step: f32, gravity: &Vector3<f32>) {
 
     for vertex in &mut mesh.vertices {
         let old_position = vertex.position;
-        vertex.position =
-            vertex.position + (vertex.position - vertex.old_position) + vertex.acceleration * time_step * time_step;
+        vertex.position = vertex.position
+            + (vertex.position - vertex.old_position)
+            + vertex.acceleration * time_step * time_step;
         vertex.old_position = old_position;
     }
 }

--- a/tests/physics.rs
+++ b/tests/physics.rs
@@ -1,6 +1,6 @@
+use nalgebra::Vector3;
 use rust_learning_project::mesh::{Mesh, Vertex};
 use rust_learning_project::physics::Spring;
-use nalgebra::Vector3;
 
 #[test]
 fn test_spring_force() {
@@ -66,10 +66,7 @@ fn test_verlet_integration() {
 
 #[test]
 fn test_oscillation() {
-    let mut mesh = Mesh::new(
-        &[0.0, 0.0, 0.0, 1.1, 0.0, 0.0],
-        &[],
-    );
+    let mut mesh = Mesh::new(&[0.0, 0.0, 0.0, 1.1, 0.0, 0.0], &[]);
     mesh.vertices[0].mass = 0.0; // Pin this vertex
     mesh.springs = vec![Spring {
         vertex_a_index: 0,

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,5 +1,5 @@
-use wasm_bindgen_test::*;
 use rust_learning_project::FaceController;
+use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -11,9 +11,7 @@ fn get_vertex_positions(controller: &FaceController, num_vertices: usize) -> Vec
 
 #[wasm_bindgen_test]
 fn test_face_controller_new() {
-    let positions = vec![
-        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
-    ];
+    let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
     let indices = vec![0, 1, 2, 0, 2, 3];
     let controller = FaceController::new(&positions, &indices);
     assert!(!controller.get_vertex_buffer_ptr().is_null());
@@ -21,9 +19,7 @@ fn test_face_controller_new() {
 
 #[wasm_bindgen_test]
 fn test_tick() {
-    let positions = vec![
-        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
-    ];
+    let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
     let indices = vec![0, 1, 2, 0, 2, 3];
     let mut controller = FaceController::new(&positions, &indices);
 
@@ -36,9 +32,7 @@ fn test_tick() {
 
 #[wasm_bindgen_test]
 fn test_mouse_interaction() {
-    let positions = vec![
-        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
-    ];
+    let positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0];
     let indices = vec![0, 1, 2, 0, 2, 3];
     let mut controller = FaceController::new(&positions, &indices);
 


### PR DESCRIPTION
## Summary
- include rustfmt in rust-toolchain components
- ensure setup_dev.sh installs rustfmt
- format mesh, physics and test modules

## Testing
- `cargo fmt --all --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a48347c334832cae588a3c62fbf5b9