### PR TITLE
docs: expand breakdowns with tests and docs steps

### DIFF
--- a/TODO/phase_1_breakdown.md
+++ b/TODO/phase_1_breakdown.md
@@ -1,0 +1,115 @@
+# Phase 1: Implementation Breakdown
+
+The following plan expands each task from `phase_1.md` into concrete implementation steps with required tests and documentation updates.
+
+## 1.1 Environment and Toolchain Configuration
+
+### 1.1.1 Install Rust Toolchain
+- **Implementation**
+  - [ ] Install rustup: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`.
+  - [ ] Create `rust-toolchain.toml` specifying the required Rust channel.
+  - [ ] Reload the shell so `cargo` and `rustc` are on `PATH`.
+- **Tests**
+  - [ ] Run `rustc --version` and `cargo --version` to confirm versions match `rust-toolchain.toml`.
+- **Documentation**
+  - [ ] Record installation steps and pinned Rust version in `docs/setup.md`.
+
+### 1.1.2 Install WebAssembly Build Target
+- **Implementation**
+  - [ ] Add the target: `rustup target add wasm32-unknown-unknown`.
+- **Tests**
+  - [ ] Verify with `rustup target list --installed | grep wasm32-unknown-unknown`.
+- **Documentation**
+  - [ ] Note the added target and verification command in `docs/setup.md`.
+
+### 1.1.3 Establish Code Repository and Version Control
+- **Implementation**
+  - [ ] Initialize git in the project root and create the `main` branch.
+  - [ ] Create `.gitignore` excluding build artifacts and editor files.
+  - [ ] Define a branching strategy such as GitFlow.
+  - [ ] Configure CI to run `cargo fmt -- --check` and `cargo test` on every pull request.
+- **Tests**
+  - [ ] Ensure CI runs `cargo fmt -- --check` and `cargo test` successfully on an initial pull request.
+- **Documentation**
+  - [ ] Update `CONTRIBUTING.md` with branching strategy, commit message style, and CI expectations.
+
+## 1.2 Build System and Bundler Selection
+
+### 1.2.1 Analysis of Bundler Options
+- **Implementation**
+  - [ ] Build a wasm-pack prototype noting JavaScript integration steps.
+  - [ ] Build a Trunk prototype using `trunk serve` and record build speed and developer experience.
+- **Tests**
+  - [ ] Confirm each prototype compiles and serves a basic page without errors.
+- **Documentation**
+  - [ ] Summarize prototype findings in `ARCHITECTURE.md`.
+
+### 1.2.2 Architectural Decision and Justification
+- **Implementation**
+  - [ ] Select Trunk as the bundler based on prototype results.
+- **Tests**
+  - [ ] Smoke-test `trunk serve` to ensure the build pipeline works end to end.
+- **Documentation**
+  - [ ] Record the decision and reasoning in `ARCHITECTURE.md`.
+
+### 1.2.3 Initial Trunk Configuration
+- **Implementation**
+  - [ ] Install tools: `cargo install trunk wasm-bindgen-cli`.
+  - [ ] Create `index.html` with a `<canvas>` element and `<link data-trunk rel="rust" />` tag.
+  - [ ] Run the development server with `trunk serve`.
+- **Tests**
+  - [ ] Visit `http://localhost:8080` and confirm a blank page is served without console errors.
+- **Documentation**
+  - [ ] Add Trunk setup instructions to `README.md`.
+
+## 1.3 Rendering Architecture Selection
+
+### 1.3.1 Analysis of Rendering Options
+- **Implementation**
+  - [ ] Prototype Option A: Rust/Wasm for logic with Three.js for rendering.
+  - [ ] Prototype Option B: Pure Rust with `web-sys` WebGL calls.
+  - [ ] Measure performance and complexity of both prototypes.
+- **Tests**
+  - [ ] Ensure both prototypes compile and render a simple object in the browser.
+- **Documentation**
+  - [ ] Record performance metrics and trade-offs in `ARCHITECTURE.md`.
+
+### 1.3.2 Architectural Decision and Justification
+- **Implementation**
+  - [ ] Choose the two-stack architecture (Rust logic + Three.js rendering).
+- **Tests**
+  - [ ] Verify a sample Three.js scene can call a Rust function compiled to Wasm.
+- **Documentation**
+  - [ ] Summarize the decision and rationale in `ARCHITECTURE.md`.
+
+### 1.3.3 Initial Project Scaffolding
+- **Implementation**
+  - [ ] Update `index.html` with `<canvas id="main-canvas">`.
+  - [ ] Create `main.js` to set up a basic Three.js renderer, camera, and scene.
+  - [ ] Run `trunk serve` to view the empty scene.
+- **Tests**
+  - [ ] Visually confirm the scene renders and no console errors appear.
+- **Documentation**
+  - [ ] Document project layout and initial Three.js setup in `README.md`.
+
+## 1.4 "Hello, Wasm!" – Initial Integration Test
+
+### 1.4.1 Create a Simple Rust Wasm Function
+- **Implementation**
+  - [ ] Add `wasm-bindgen = "0.2"` to `Cargo.toml`.
+  - [ ] Implement an `add(a: i32, b: i32) -> i32` function in `src/main.rs` annotated with `#[wasm_bindgen]`.
+  - [ ] Build using `trunk build` or `trunk serve`.
+- **Tests**
+  - [ ] Write a Rust unit test asserting `add(2,3) == 5`.
+  - [ ] Add a wasm-bindgen test to ensure the function exports correctly.
+- **Documentation**
+  - [ ] Include the example function and build instructions in `docs/wasm.md`.
+
+### 1.4.2 Call the Wasm Function from JavaScript
+- **Implementation**
+  - [ ] Import the generated module in `main.js` and log the result of `add(2,3)`.
+- **Tests**
+  - [ ] Manual browser test verifying the expected value appears in the console.
+- **Documentation**
+  - [ ] Document JavaScript/Wasm integration steps in `docs/wasm.md`.
+

--- a/TODO/phase_2_breakdown.md
+++ b/TODO/phase_2_breakdown.md
@@ -1,0 +1,77 @@
+# Phase 2: Implementation Breakdown
+
+The following plan expands each task from `phase_2.md` into concrete implementation steps with completion checkboxes, tests, and documentation updates.
+
+## 2.1 Data Structures for Mesh Representation
+
+### 2.1.1 Define Vertex and Mesh Structs
+- **Implementation**
+  - [ ] Introduce a small vector math module or dependency for 3D operations.
+  - [ ] Create a `Vertex` struct with current, previous, and resting positions plus acceleration.
+  - [ ] Create a `Mesh` struct owning `Vec<Vertex>` and connectivity data.
+- **Tests**
+  - [ ] Write unit tests covering vector addition, subtraction, and normalization.
+- **Documentation**
+  - [ ] Describe the `Vertex` layout and `Mesh` ownership model in `docs/mesh.md`.
+
+### 2.1.2 Implement Mesh Initialization
+- **Implementation**
+  - [ ] Expose an `init_mesh(vertices: &[f32], indices: &[u32])` function with `#[wasm_bindgen]`.
+  - [ ] Parse flat arrays into internal `Mesh` and `Vertex` collections.
+  - [ ] Handle invalid input lengths and return meaningful errors.
+- **Tests**
+  - [ ] wasm-bindgen test passing a cube mesh and verifying vertex/face counts and error handling.
+- **Documentation**
+  - [ ] Document the initialization API and expected array formats in `docs/mesh.md`.
+
+## 2.2 Physics Engine Implementation
+
+### 2.2.1 Architectural Decision: Custom Physics Model
+- **Implementation**
+  - [ ] Finalize constants for spring stiffness and damping after experimentation.
+- **Tests**
+  - [ ] Benchmark different constants and compare results to choose stable values.
+- **Documentation**
+  - [ ] Record rationale for a bespoke spring-mass system and chosen constants in `ARCHITECTURE.md`.
+
+### 2.2.2 Implement Spring-Mass System
+
+#### 2.2.2.1 Define Spring Constraints
+- **Implementation**
+  - [ ] Create a `Spring` struct linking two vertex indices with stiffness `k` and damping `b`.
+  - [ ] Implement force calculation using Hooke’s Law with a damping term.
+- **Tests**
+  - [ ] Unit test forces on a two-node system for correct restoring and damping behavior.
+- **Documentation**
+  - [ ] Document the spring constraint equations in `docs/physics.md`.
+
+#### 2.2.2.2 Implement Numerical Integration
+- **Implementation**
+  - [ ] Implement Verlet integration to update vertex positions each tick.
+  - [ ] Apply accumulated spring and external forces to compute acceleration.
+- **Tests**
+  - [ ] Write tests verifying motion under constant force and oscillation in a simple spring.
+- **Documentation**
+  - [ ] Explain the integration scheme and update `docs/physics.md`.
+
+## 2.3 Wasm API Design and Implementation
+
+### 2.3.1 Define the Public Wasm Struct
+- **Implementation**
+  - [ ] Create a `FaceController` struct annotated with `#[wasm_bindgen]` encapsulating the mesh and physics state.
+  - [ ] Implement a constructor that builds the mesh from provided arrays.
+- **Tests**
+  - [ ] Integration test ensuring JavaScript can instantiate the controller.
+- **Documentation**
+  - [ ] Document `FaceController` fields and constructor usage in `docs/api.md`.
+
+### 2.3.2 Implement State Update and I/O Functions
+- **Implementation**
+  - [ ] Add `tick(dt: f32)` to advance the physics simulation.
+  - [ ] Add mouse interaction handlers: `on_mouse_down`, `on_mouse_move`, and `on_mouse_up`.
+  - [ ] Implement `get_vertex_buffer_ptr() -> *const f32` returning a pointer to the vertex buffer.
+- **Tests**
+  - [ ] Integration tests verifying state updates and that the returned pointer is non-null.
+- **Documentation**
+  - [ ] Update `docs/api.md` with function descriptions and usage examples.
+

--- a/TODO/phase_3_breakdown.md
+++ b/TODO/phase_3_breakdown.md
@@ -1,0 +1,86 @@
+# Phase 3: Implementation Breakdown
+
+The following plan expands each task from `phase_3.md` into concrete implementation steps with completion checkboxes, tests, and documentation updates.
+
+## 3.1 Scene Setup
+
+### 3.1.1 Initialize Three.js Environment
+- **Implementation**
+  - [ ] Create `main.js` and import required Three.js modules including `OrbitControls`.
+  - [ ] Instantiate `THREE.Scene`, `THREE.PerspectiveCamera`, and `THREE.WebGLRenderer` bound to `<canvas id="main-canvas">`.
+  - [ ] Configure renderer size to the window and append its DOM element to the document.
+  - [ ] Add `THREE.AmbientLight` and `THREE.DirectionalLight` to illuminate the model.
+  - [ ] Enable `OrbitControls` on the camera with damping for smooth interaction.
+  - [ ] Register a window `resize` handler to update camera aspect and renderer size.
+- **Tests**
+  - [ ] Manual verification that an empty, lit scene appears and is rotatable when served via `trunk`.
+- **Documentation**
+  - [ ] Document Three.js setup and control configuration in `docs/frontend.md`.
+
+## 3.2 Mesh Loading and Initialization
+
+### 3.2.1 Load 3D Face Model
+- **Implementation**
+  - [ ] Import `GLTFLoader` (or similar) and load a low-polygon face model.
+  - [ ] On load, center and scale the mesh, then add it to the scene.
+- **Tests**
+  - [ ] Visual test confirming the model renders at the origin with expected orientation.
+- **Documentation**
+  - [ ] Record the model source and loading steps in `docs/frontend.md`.
+
+### 3.2.2 Initialize Wasm Module with Mesh Data
+- **Implementation**
+  - [ ] Extract vertex position and index arrays from the mesh's geometry.
+  - [ ] Pass these arrays to the Wasm `FaceController` constructor and keep the instance globally.
+  - [ ] Log vertex and index counts in both JavaScript and Rust for verification.
+- **Tests**
+  - [ ] Integration test ensuring counts logged in JS match those reported by Rust.
+- **Documentation**
+  - [ ] Document the data transfer process to Wasm in `docs/frontend.md`.
+
+## 3.3 User Interaction and Raycasting
+
+### 3.3.1 Implement Mouse Event Listeners
+- **Implementation**
+  - [ ] Attach `mousedown`, `mousemove`, and `mouseup` listeners to the canvas.
+  - [ ] Track the selected vertex ID and whether the user is currently dragging.
+- **Tests**
+  - [ ] Manual test confirming drag state toggles correctly on mouse events.
+- **Documentation**
+  - [ ] Describe the mouse event flow in `docs/frontend.md`.
+
+### 3.3.2 Implement Raycasting for Vertex Selection
+- **Implementation**
+  - [ ] On `mousedown`, convert screen coordinates to normalized device coordinates.
+  - [ ] Use `THREE.Raycaster` to intersect the face mesh and obtain the closest hit.
+  - [ ] Determine the nearest vertex index to the intersection point.
+  - [ ] Call `faceController.on_mouse_down(vertex_id, ...)` and visually highlight the selection.
+- **Tests**
+  - [ ] Manual test selecting multiple vertices to ensure correct indices are reported.
+- **Documentation**
+  - [ ] Update `docs/frontend.md` with raycasting math and selection visuals.
+
+## 3.4 The Render Loop
+
+### 3.4.1 Structure the `requestAnimationFrame` Loop
+- **Implementation**
+  - [ ] Implement an `animate(time)` function that calls `requestAnimationFrame(animate)`.
+  - [ ] Compute `deltaTime` between frames for physics updates.
+- **Tests**
+  - [ ] Console log `deltaTime` during development to verify timing values.
+- **Documentation**
+  - [ ] Document loop structure and timing calculations in `docs/frontend.md`.
+
+### 3.4.2 Implement Frame Logic
+- **Implementation**
+  - [ ] If dragging, compute the new 3D target position and call `faceController.on_mouse_move`.
+  - [ ] Advance physics each frame via `faceController.tick(deltaTime)`.
+  - [ ] Retrieve updated vertex data with `faceController.get_vertex_buffer_ptr()`.
+  - [ ] Map `wasmModule.memory.buffer` into a `Float32Array` and copy into the mesh's position attribute.
+  - [ ] Mark `mesh.geometry.attributes.position.needsUpdate = true`.
+  - [ ] Render the scene with `renderer.render(scene, camera)`.
+- **Tests**
+  - [ ] Manual test: drag a handle and observe mesh deformation updating each frame.
+- **Documentation**
+  - [ ] Document data flow from Wasm to Three.js in `docs/frontend.md`.
+

--- a/TODO/phase_4_breakdown.md
+++ b/TODO/phase_4_breakdown.md
@@ -1,0 +1,74 @@
+# Phase 4: Implementation Breakdown
+
+The following plan expands each task from `phase_4.md` into concrete implementation steps with completion checkboxes, tests, and documentation updates.
+
+## 4.1 Face Detection for Vertex Interaction
+
+### 4.1.1 Integrate a Face Detection Library
+- **Implementation**
+  - [ ] Evaluate WebAssembly-compatible face detection libraries (e.g., `rust-faces`).
+  - [ ] Add the chosen library and its model files to the build process.
+  - [ ] Expose a Wasm function that accepts image bytes and returns facial landmark coordinates.
+  - [ ] Map landmark coordinates to nearest vertices on the 3D mesh and mark them as interactive handles.
+  - [ ] Highlight mapped vertices in Three.js using small spheres or colored points.
+- **Tests**
+  - [ ] Unit test mapping logic with synthetic coordinates to ensure correct vertex indices are selected.
+  - [ ] Integration test running detection on a sample image and confirming landmarks are returned and highlighted.
+- **Documentation**
+  - [ ] Document library selection, model loading, and landmark-to-vertex mapping in `docs/face_detection.md`.
+
+### 4.1.2 Handle Image Input for Detection
+- **Implementation**
+  - [ ] Accept image uploads or camera input and convert data into the format required by the detector.
+  - [ ] Pass image data to the Wasm detection function upon load.
+- **Tests**
+  - [ ] Test that image data is correctly decoded and passed to Wasm using a known image.
+  - [ ] Manual test: upload an image and verify markers appear on corresponding facial features.
+- **Documentation**
+  - [ ] Update `docs/face_detection.md` with image input workflow and troubleshooting tips.
+
+## 4.2 Image-Based Face Stretching
+
+### 4.2.1 Implement Image Upload and Texture Mapping
+- **Implementation**
+  - [ ] Add an `<input type="file">` element to the HTML for image uploads.
+  - [ ] Use JavaScript to read the image into an `ArrayBuffer`.
+  - [ ] Apply the image as a texture on the 3D face model using `THREE.TextureLoader` and `MeshBasicMaterial`.
+  - [ ] Store the original image data for further processing.
+- **Tests**
+  - [ ] Manual test uploading various image formats to ensure textures display correctly.
+  - [ ] Integration test verifying texture dimensions match the mesh UV layout.
+- **Documentation**
+  - [ ] Document the upload UI and texture-mapping steps in `docs/frontend.md`.
+
+### 4.2.2 Wasm-Powered Image Pre-processing
+- **Implementation**
+  - [ ] Add `photon-rs` as a dependency compiled to Wasm.
+  - [ ] Implement a Rust function to accept raw image data and apply operations such as resizing or filters (grayscale, sepia).
+  - [ ] Return the processed buffer to JavaScript to update the texture.
+- **Tests**
+  - [ ] Unit tests for each filter validating output dimensions and pixel values.
+  - [ ] Integration test demonstrating a filter applied to a sample image and rendered on the model.
+- **Documentation**
+  - [ ] Create `docs/image_processing.md` detailing available filters and usage examples.
+
+### 4.2.3 User Interface for Filter Selection
+- **Implementation**
+  - [ ] Add UI controls (dropdown or buttons) for choosing image filters.
+  - [ ] Wire controls to call the Wasm pre-processing functions with the selected filter.
+- **Tests**
+  - [ ] Manual test ensuring UI actions trigger filter application and texture updates.
+  - [ ] Automated test verifying the correct filter name is passed from JavaScript to Wasm.
+- **Documentation**
+  - [ ] Update `docs/frontend.md` with instructions for using the filter UI.
+
+### 4.2.4 Error Handling and Fallbacks
+- **Implementation**
+  - [ ] Display user-friendly messages for unsupported file types or detection failures.
+  - [ ] Provide a fallback texture or restore the previous texture when processing fails.
+- **Tests**
+  - [ ] Tests for invalid file inputs ensuring errors are surfaced without crashes.
+  - [ ] Manual test simulating detection failure to verify fallback behavior.
+- **Documentation**
+  - [ ] Describe error handling strategy and recovery options in `README.md`.
+

--- a/TODO/phase_5_breakdown.md
+++ b/TODO/phase_5_breakdown.md
@@ -1,0 +1,104 @@
+# Phase 5: Implementation Breakdown
+
+The following plan expands each task from `phase_5.md` into concrete implementation steps with completion checkboxes, tests, and documentation updates.
+
+## 5.1 Testing Strategy Foundation
+
+### 5.1.1 Document Testing Approach
+- **Implementation**
+  - [ ] Create `docs/testing.md` outlining the two-tier strategy and naming conventions for test files.
+  - [ ] Add a section to `README.md` summarizing how to run native and Wasm tests.
+- **Tests**
+  - [ ] Ensure `docs/testing.md` includes verified command snippets for both tiers.
+- **Documentation**
+  - [ ] Cross-link `docs/testing.md` from `CONTRIBUTING.md`.
+
+### 5.1.2 Configure Test Tooling
+- **Implementation**
+  - [ ] Add `wasm-bindgen-test` and `wasm-pack` as dev-dependencies in `Cargo.toml`.
+  - [ ] Install `wasm-pack` via `cargo install wasm-pack` for local development.
+  - [ ] Set up a `Makefile` target `test-all` that runs `cargo test` followed by `wasm-pack test`.
+- **Tests**
+  - [ ] Run `wasm-pack --version` to verify installation.
+  - [ ] Execute `make test-all` locally to ensure both test suites run sequentially.
+- **Documentation**
+  - [ ] Document the `make test-all` workflow in `docs/testing.md`.
+
+### 5.1.3 Continuous Integration Pipeline
+- **Implementation**
+  - [ ] Extend CI configuration to execute `cargo test` on all pushes.
+  - [ ] Add a separate CI job invoking `wasm-pack test --headless --firefox`.
+  - [ ] Configure caching for the cargo registry and build artifacts to speed up CI.
+- **Tests**
+  - [ ] Confirm that both CI jobs pass on a test pull request.
+- **Documentation**
+  - [ ] Note CI environments, browsers used, and caching strategy in `docs/testing.md`.
+
+## 5.2 Tier 1: Native Rust Unit Tests
+
+### 5.2.1 Organize Unit Test Modules
+- **Implementation**
+  - [ ] For each core module, create an inline `mod tests` section with focused test functions.
+  - [ ] Use helper functions or fixtures for shared setup code.
+- **Tests**
+  - [ ] Run `cargo test` and ensure all modules compile and execute their tests.
+- **Documentation**
+  - [ ] Document patterns for arranging unit tests and fixtures in `docs/testing.md`.
+
+### 5.2.2 Property and Edge-Case Testing
+- **Implementation**
+  - [ ] Add `proptest` as a dev-dependency for property-based tests.
+  - [ ] Write tests exploring edge cases for spring forces, integration limits, and vector math.
+- **Tests**
+  - [ ] Execute `cargo test` with the property tests enabled and observe failures for invalid invariants.
+- **Documentation**
+  - [ ] Explain when to use property tests vs. example-based tests in `docs/testing.md`.
+
+### 5.2.3 Code Coverage Metrics
+- **Implementation**
+  - [ ] Integrate `cargo tarpaulin` for Linux-based coverage reports.
+  - [ ] Add a `make coverage` target that runs `cargo tarpaulin --ignore-tests`.
+- **Tests**
+  - [ ] Run `make coverage` and verify that coverage exceeds the 90% threshold for physics modules.
+- **Documentation**
+  - [ ] Record coverage commands and badge setup instructions in `docs/testing.md`.
+
+## 5.3 Tier 2: Wasm Integration and E2E Tests
+
+### 5.3.1 Set Up wasm-bindgen-test Harness
+- **Implementation**
+  - [ ] Create test files under `tests/` using the `#[wasm_bindgen_test]` macro.
+  - [ ] Export public functions from `FaceController` for testing via `wasm_bindgen`.
+- **Tests**
+  - [ ] Run `wasm-pack test --headless --firefox` to execute the harness.
+- **Documentation**
+  - [ ] Document the harness setup and example tests in `docs/testing.md`.
+
+### 5.3.2 Browser End-to-End Interaction Tests
+- **Implementation**
+  - [ ] Choose a browser automation framework such as Playwright.
+  - [ ] Write a script that loads the Web page, injects a mesh, performs a drag interaction, and verifies vertex movement.
+- **Tests**
+  - [ ] Execute the automation script in CI using `wasm-pack test --headless` combined with the framework's CLI.
+  - [ ] Ensure the script captures screenshots or console logs on failure.
+- **Documentation**
+  - [ ] Add an end-to-end testing section in `docs/testing.md` with instructions for running the automation locally.
+
+### 5.3.3 Cross-Browser Validation
+- **Implementation**
+  - [ ] Configure `wasm-pack test` to run against both Firefox and Chrome in CI.
+  - [ ] Investigate any discrepancies in behavior and add polyfills if necessary.
+- **Tests**
+  - [ ] Verify that both `wasm-pack test --headless --firefox` and `--chrome` pass.
+- **Documentation**
+  - [ ] Document supported browsers and known issues in `docs/testing.md`.
+
+### 5.3.4 Performance and Memory Profiling
+- **Implementation**
+  - [ ] Use browser devtools to record memory usage and frame rates during automated tests.
+  - [ ] Set thresholds for acceptable performance metrics.
+- **Tests**
+  - [ ] Include assertions in the automation script ensuring frame rate stays above target and memory does not leak.
+- **Documentation**
+  - [ ] Record profiling methodology and thresholds in `docs/testing.md`.
+

--- a/TODO/phase_6_breakdown.md
+++ b/TODO/phase_6_breakdown.md
@@ -1,0 +1,73 @@
+# Phase 6: Implementation Breakdown
+
+The following plan expands each task from `phase_6.md` into concrete implementation steps with completion checkboxes, tests, and documentation updates.
+
+## 6.1 Build Optimization
+
+### 6.1.1 Enable Release Optimizations
+- **Implementation**
+  - [ ] Set `[profile.release]` in `Cargo.toml` with `lto = true` and `opt-level = "z"` for size-focused builds.
+  - [ ] Run `trunk build --release` to generate optimized artifacts.
+  - [ ] Add a `Makefile` target `build-release` invoking the above command for repeatable builds.
+- **Tests**
+  - [ ] Compare the size of `dist/*.wasm` between debug and release builds to confirm reduction.
+  - [ ] Execute `make build-release` and ensure the command completes without errors.
+- **Documentation**
+  - [ ] Record release build flags and expected file sizes in `docs/optimizations.md`.
+  - [ ] Reference `build-release` in the "Building" section of `README.md`.
+
+### 6.1.2 Integrate `wasm-opt`
+- **Implementation**
+  - [ ] Install Binaryen’s `wasm-opt` tool (e.g., `cargo install wasm-opt` or system package manager).
+  - [ ] Configure Trunk’s release pipeline to run `wasm-opt -O` on the generated `.wasm` file.
+  - [ ] Include the optimization step in the `build-release` target.
+- **Tests**
+  - [ ] Run `wasm-opt --version` to verify the tool is available.
+  - [ ] After running `make build-release`, inspect `dist/*.wasm` to ensure the optimization step executes (file size shrinks or `wasm-opt` logs appear).
+- **Documentation**
+  - [ ] Document installation and usage of `wasm-opt` in `docs/optimizations.md` with command examples.
+
+### 6.1.3 Profile Performance
+- **Implementation**
+  - [ ] Serve the release build locally using `trunk serve --release` or a static server.
+  - [ ] Use browser DevTools to capture frame render times and memory usage.
+  - [ ] Adjust physics parameters or rendering settings if profiling reveals bottlenecks.
+- **Tests**
+  - [ ] Capture a performance profile demonstrating stable ~60 FPS on reference hardware.
+  - [ ] Log memory allocations to ensure they remain within acceptable bounds.
+- **Documentation**
+  - [ ] Summarize profiling methodology and findings in `docs/performance.md`.
+
+## 6.2 Deployment
+
+### 6.2.1 Prepare `dist` for Hosting
+- **Implementation**
+  - [ ] Run `make build-release` to produce the final `dist/` directory.
+  - [ ] Verify `index.html`, `*.wasm`, and JS glue code exist and reference one another correctly.
+- **Tests**
+  - [ ] Serve `dist/` locally (`npx serve dist` or similar) and confirm the app loads without console errors.
+- **Documentation**
+  - [ ] Document the contents and purpose of the `dist/` directory in `docs/deployment.md`.
+
+### 6.2.2 Configure Hosting Service
+- **Implementation**
+  - [ ] Choose a static host (e.g., GitHub Pages, Netlify, Vercel).
+  - [ ] Add deployment configuration: for GitHub Pages, create a GitHub Actions workflow that uploads `dist/`; for Netlify/Vercel, define a project pointing to `dist/`.
+  - [ ] Store any necessary access tokens or secrets securely in CI settings.
+- **Tests**
+  - [ ] Trigger the deployment workflow and verify it completes successfully.
+  - [ ] Confirm the hosted URL serves the same `dist/` contents as the local build.
+- **Documentation**
+  - [ ] Provide step-by-step hosting setup instructions and URLs in `docs/deployment.md`.
+  - [ ] Add the production URL to `README.md`.
+
+### 6.2.3 Validate Production Site
+- **Implementation**
+  - [ ] Load the public URL on multiple browsers and devices.
+  - [ ] Execute a smoke test of major features: loading the mesh, interacting with vertices, and observing physics.
+- **Tests**
+  - [ ] Record screenshots or logs confirming cross-browser functionality.
+  - [ ] Monitor network requests to ensure assets are served with correct MIME types and caching headers.
+- **Documentation**
+  - [ ] Append a "Verification" section to `docs/deployment.md` noting testing steps and results.
+


### PR DESCRIPTION
## Summary
- add detailed `phase_5_breakdown.md` outlining tiered testing strategy with implementation, tests, and docs steps
- add detailed `phase_4_breakdown.md` covering face detection, image-based stretching, and related tests and docs
- augment phase 1–3 breakdowns with explicit testing and documentation tasks
- add detailed `phase_6_breakdown.md` describing build optimization and deployment steps with tests and docs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a47a631788832cba274a633cfbfc5d