### PR TITLE
Provide default implementation for Physics

### DIFF
--- a/src/physics.rs
+++ b/src/physics.rs
@@ -14,12 +14,18 @@ pub struct Physics {
     pub gravity: Vector3<f32>,
 }
 
-impl Physics {
-    pub fn new() -> Self {
+impl Default for Physics {
+    fn default() -> Self {
         Self {
             time_step: 0.01,
             gravity: Vector3::new(0.0, -9.81, 0.0),
         }
+    }
+}
+
+impl Physics {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 use rust_learning_project::FaceController;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
## Summary
- implement `Default` for `Physics`
- use `Self::default()` in constructor
- limit wasm tests to wasm32 target to avoid clippy dead_code warnings

## Testing
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a48793a13c832cab7c94024f6beb98