### PR TITLE
docs: refine agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS
+
+Guidelines for contributors working in this Rust and WebAssembly project. These
+instructions ensure consistent engineering practices and mirror the checks run
+by GitHub Actions so issues are caught before opening a pull request.
+
+## Workflow
+- Use a pull‑request based workflow. Keep commits small and focused with clear
+  messages.
+- Update `CHANGELOG.md` under **Unreleased** for every user‑facing change.
+- Keep documentation up to date (e.g. `README.md`, `docs/`).
+- Use `rg` for searching and avoid `ls -R` or `grep -R`.
+
+## Code style
+- Format Rust code with `cargo fmt --all` before committing.
+- Treat all Clippy warnings as errors.
+- Document public items with Rustdoc comments.
+
+## Required checks (parity with GitHub Actions)
+Run the following commands locally and include their results in the pull
+request:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features --workspace -- -D warnings
+cargo test --all-features --workspace
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --all-features --workspace --examples
+```
+
+## Git hygiene
+- Only commit files relevant to your change and ensure the worktree is clean
+  before committing.
+- Do not bypass required checks or CI failures.
+
+Following these practices keeps the codebase healthy and contributions
+maintainable.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Clarify AGENTS instructions around testing and code style
+- Implement `Default` for `Physics` and silence clippy `dead_code` in wasm tests

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -23,6 +23,12 @@ impl Physics {
     }
 }
 
+impl Default for Physics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub fn update(mesh: &mut Mesh, time_step: f32, gravity: &Vector3<f32>) {
     for vertex in &mut mesh.vertices {
         vertex.acceleration = *gravity;

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use rust_learning_project::FaceController;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
## Summary
- generalize AGENTS.md to emphasize workflow, style, and parity with CI checks
- implement `Default` for `Physics` and silence `dead_code` warnings in wasm tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- `cargo test --all-features --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items --all-features --workspace --examples`


------
https://chatgpt.com/codex/tasks/task_e_68a4884be394832c99cacfa524530e3b