### PR TITLE
Fix clippy warnings and update image crate usage

### DIFF
--- a/src/face_detection.rs
+++ b/src/face_detection.rs
@@ -1,4 +1,4 @@
-use image::{GenericImageView, ImageError};
+use image::GenericImageView;
 use std::error::Error;
 use tensorflow::{Graph, ImportGraphDefOptions, Session, SessionOptions, SessionRunArgs, Tensor};
 
@@ -15,7 +15,7 @@ pub fn detect_faces(image_bytes: &[u8]) -> Result<Vec<BBox>, Box<dyn Error>> {
     let model = include_bytes!("../assets/mtcnn.pb");
 
     let mut graph = Graph::new();
-    graph.import_graph_def(&*model, &ImportGraphDefOptions::new())?;
+    graph.import_graph_def(model, &ImportGraphDefOptions::new())?;
 
     let input_image = image::load_from_memory(image_bytes)?;
 

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use photon_rs::{monochrome, native::open_image_from_bytes, PhotonImage};
+use photon_rs::{monochrome, native::open_image_from_bytes};
 
 #[wasm_bindgen]
 pub fn apply_grayscale(image_bytes: &[u8]) -> Result<Vec<u8>, JsValue> {


### PR DESCRIPTION
This commit addresses two issues that were causing the CI to fail:

1.  A `clippy::borrow-deref-ref` lint error in `src/face_detection.rs` has been fixed by removing the redundant `&*`.
2.  Unused imports have been removed from `src/face_detection.rs` and `src/image_processing.rs`.

The issue with `img.write_to` was investigated and found to be already resolved in the codebase.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
