### PR TITLE
Fix: Reformat img.write_to call in test

### DIFF
--- a/tests/image_processing.rs
+++ b/tests/image_processing.rs
@@ -8,8 +8,11 @@ fn create_test_image() -> Vec<u8> {
     img.put_pixel(0, 1, Rgba([0, 0, 255, 255]));
     img.put_pixel(1, 1, Rgba([255, 255, 0, 255]));
     let mut bytes: Vec<u8> = Vec::new();
-    img.write_to(&mut std::io::Cursor::new(&mut bytes), image::ImageOutputFormat::Png)
-        .expect("Failed to write test image");
+    img.write_to(
+        &mut std::io::Cursor::new(&mut bytes),
+        image::ImageOutputFormat::Png,
+    )
+    .expect("Failed to write test image");
     bytes
 }
 


### PR DESCRIPTION
The `img.write_to` function call in `tests/image_processing.rs` was formatted in a way that caused issues with the build process.

This change reformats the function call to a multi-line format, which is more idiomatic and resolves the build failure.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
