### PR TITLE
Fix(ci): Resolve image processing test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ photon-rs = "0.3.1"
 serde-wasm-bindgen = "0.4"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.42"
+image = "0.24"
+photon-rs = "0.3"
+wasm-bindgen-test = "0.3"
 
 [[test]]
 name = "physics"

--- a/src/face_detection.rs
+++ b/src/face_detection.rs
@@ -26,12 +26,8 @@ pub fn detect_faces(image_bytes: &[u8]) -> Result<Vec<BBox>, Box<dyn Error>> {
         flattened.push(rgb[0] as f32);
     }
 
-    let input = Tensor::new(&[
-        input_image.height() as u64,
-        input_image.width() as u64,
-        3,
-    ])
-    .with_values(&flattened)?;
+    let input = Tensor::new(&[input_image.height() as u64, input_image.width() as u64, 3])
+        .with_values(&flattened)?;
 
     let min_size = Tensor::new(&[]).with_values(&[40f32])?;
     let thresholds = Tensor::new(&[3]).with_values(&[0.6f32, 0.7f32, 0.7f32])?;

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -1,18 +1,18 @@
-use wasm_bindgen::prelude::*;
 use photon_rs::{monochrome, native::open_image_from_bytes};
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn apply_grayscale(image_bytes: &[u8]) -> Result<Vec<u8>, JsValue> {
-    let mut img = open_image_from_bytes(image_bytes)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let mut img =
+        open_image_from_bytes(image_bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
     monochrome::grayscale(&mut img);
     Ok(img.get_raw_pixels())
 }
 
 #[wasm_bindgen]
 pub fn apply_sepia(image_bytes: &[u8]) -> Result<Vec<u8>, JsValue> {
-    let mut img = open_image_from_bytes(image_bytes)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let mut img =
+        open_image_from_bytes(image_bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
     monochrome::sepia(&mut img);
     Ok(img.get_raw_pixels())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-pub mod mesh;
-pub mod physics;
 pub mod face_detection;
 pub mod image_processing;
+pub mod mesh;
+pub mod physics;
 
 use crate::mesh::Mesh;
 use crate::physics::Physics;
@@ -21,8 +21,8 @@ pub struct BBox {
 
 #[wasm_bindgen]
 pub fn detect_faces(image_bytes: &[u8]) -> Result<JsValue, JsValue> {
-    let bboxes = face_detection::detect_faces(image_bytes)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let bboxes =
+        face_detection::detect_faces(image_bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
     let result: Vec<BBox> = bboxes
         .into_iter()
         .map(|bbox| BBox {

--- a/tests/image_processing.rs
+++ b/tests/image_processing.rs
@@ -1,5 +1,5 @@
-use rust_learning_project::image_processing;
 use image::{ImageBuffer, Rgba};
+use rust_learning_project::image_processing;
 
 fn create_test_image() -> Vec<u8> {
     let mut img: ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::new(2, 2);


### PR DESCRIPTION
The image processing tests were failing in CI. This was caused by missing dev-dependencies in `Cargo.toml`. The tests use the `image` and `photon-rs` crates, which were only listed as main dependencies.

This commit resolves the issue by adding `image`, `photon-rs`, and `wasm-bindgen-test` to the `[dev-dependencies]` section in `Cargo.toml`, ensuring the test environment is correctly configured.

Additionally, the codebase has been formatted with `cargo fmt --all` to adhere to the project's coding style guidelines as specified in AGENTS.md. This resulted in some cosmetic changes in several files.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
