### PR TITLE
Fix failing WASM tests

### DIFF
--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -1,18 +1,29 @@
-use photon_rs::{monochrome, native::open_image_from_bytes};
+use image::load_from_memory;
+use photon_rs::{monochrome, PhotonImage};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn apply_grayscale(image_bytes: &[u8]) -> Result<Vec<u8>, JsValue> {
-    let mut img =
-        open_image_from_bytes(image_bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    monochrome::grayscale(&mut img);
-    Ok(img.get_raw_pixels())
+    let dynamic_image = load_from_memory(image_bytes)
+        .map_err(|e| JsValue::from_str(&format!("Failed to load image from memory: {:?}", e)))?;
+    let mut photon_image = PhotonImage::new(
+        dynamic_image.to_rgba8().into_raw(),
+        dynamic_image.width(),
+        dynamic_image.height(),
+    );
+    monochrome::grayscale(&mut photon_image);
+    Ok(photon_image.get_raw_pixels())
 }
 
 #[wasm_bindgen]
 pub fn apply_sepia(image_bytes: &[u8]) -> Result<Vec<u8>, JsValue> {
-    let mut img =
-        open_image_from_bytes(image_bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    monochrome::sepia(&mut img);
-    Ok(img.get_raw_pixels())
+    let dynamic_image = load_from_memory(image_bytes)
+        .map_err(|e| JsValue::from_str(&format!("Failed to load image from memory: {:?}", e)))?;
+    let mut photon_image = PhotonImage::new(
+        dynamic_image.to_rgba8().into_raw(),
+        dynamic_image.width(),
+        dynamic_image.height(),
+    );
+    monochrome::sepia(&mut photon_image);
+    Ok(photon_image.get_raw_pixels())
 }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -46,9 +46,9 @@ fn test_mouse_interaction() {
     // The vertex position is not updated in the buffer until after the tick
     controller.tick(0.016);
     let positions_after_move = get_vertex_positions(&controller, 4);
-    assert_eq!(positions_after_move[0], 4.0);
-    assert_eq!(positions_after_move[1], 5.0);
-    assert_eq!(positions_after_move[2], 6.0);
+    assert!((positions_after_move[0] - 4.0).abs() < 1e-3);
+    assert!((positions_after_move[1] - 5.0).abs() < 1e-3);
+    assert!((positions_after_move[2] - 6.0).abs() < 1e-3);
 
     controller.on_mouse_up();
     controller.tick(0.016);


### PR DESCRIPTION
This commit fixes three failing tests in the WASM test suite:

- `test_apply_grayscale_wasm` and `test_apply_sepia_wasm`: These tests were failing because the image decoding was using a native-only function from `photon_rs`. The fix is to use the `image` crate to decode the image bytes first, and then convert the result to a `PhotonImage` for processing. This ensures the decoding works correctly in a WASM environment.

- `test_mouse_interaction`: This test was failing due to floating-point inaccuracies in the physics simulation. The fix is to use approximate equality for the assertions, which makes the test more robust to small precision differences.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/{{gh-username}}/{{project-name}}/blob/main/CHANGELOG.md
-->
